### PR TITLE
Two sets of fixes:

### DIFF
--- a/powercat.ps1
+++ b/powercat.ps1
@@ -595,9 +595,10 @@ Examples:
   ########## POWERSHELL FUNCTIONS ##########
   function Main_Powershell
   {
-    param($Stream1SetupVars)
+    param($Stream1SetupVars)   
     try
     {
+      $encoding = New-Object System.Text.AsciiEncoding
       [byte[]]$InputToWrite = @()
       if($i -ne $null)
       {
@@ -644,8 +645,8 @@ Examples:
           $ReturnedData = $null
           if($CommandToExecute -ne "")
           {
-            try{[byte[]]$ReturnedData = $Encoding.GetBytes((IEX $CommandToExecute 2>&1 | Out-String))}
-            catch{}
+            try{[byte[]]$ReturnedData = $Encoding.GetBytes((IEX $CommandToExecute 2>&1 3>&1 4>&1 5>&1 | Out-String))}
+            catch{[byte[]]$ReturnedData = $Encoding.GetBytes(($_ | Out-String))}
             $Prompt = $Encoding.GetBytes(("PS " + (pwd).Path + "> "))
           }
           $Data += $IntroPrompt


### PR DESCRIPTION
As discussed in issue: https://github.com/besimorhino/powercat/issues/2

1. Re added definition of $Encoding in the PowerShell section to prevent -ep client calls from failing. Line 601
2. Previous only standard out (pipeline) was captured and returned when using -ep, there were no errors captured. EG, if you typed an invalid CMDLet, nothing was returned. Modified IEX call in #Stream2 Read# section, line 648 to capture error, verbose, warnings and debug. also modified the catch to actually to something, it will now return the error message (and thus if you mistype a CMDLet you will see an error).